### PR TITLE
Terrain.py issues with newer digimap tiles

### DIFF
--- a/terrain.py
+++ b/terrain.py
@@ -15,7 +15,7 @@ class TerrainTile:
         num_rows_read = 0
         with open(filename, 'r', encoding='ascii') as f:
             for line in f:
-                line_bits = [item.strip() for item in line.split(' ')]
+                line_bits = [item.strip() for item in line.strip().split(' ') if item != ''] #this is to remove empty values when reading newer digimap files
                 if line_bits[0]=='nrows':
                     self.nrows = int(line_bits[1])
                     print(f'Tile has {self.nrows} rows')                    
@@ -37,8 +37,9 @@ class TerrainTile:
                         # check we've had all the data we need
                         assert self.ncols is not None
                         # initiailize the array
-                        self.Z = np.zeros((self.nrows,self.ncols))
-                    assert len(line_bits)==self.ncols
+                        self.Z = np.zeros((self.nrows,self.ncols))  
+                    assert len(line_bits)==self.ncols # this line throws errors with digimap ascii files, line 6 defines what the value for no data tiles are -9999 
+                                                        # line 6 must be removed prior to execution and any -9999 values must be replaced
                     self.Z[self.nrows - 1 - num_rows_read] = np.array(line_bits, dtype=float)
                     num_rows_read += 1
         print(f'Read {num_rows_read} rows')


### PR DESCRIPTION
Code does not combine delimiters when splitting lines into items and creates empty string values that are resolved with an if item != '', and the line is stripped prior to delimiter splitting to catch any extra spaces at the ends of each line.

Newer digimap composite lidar files include an additional information line defining no_data areas with the value of -9999. this additional line breaks the code as it is 6 terms long and not the same as the ncol value for the file. 

Additionally, any -9999 values don't throw any errors but significantly throw off the visibility of minor z value deviations on the plotted surface, due to the "cliff" forming from regular values to -9999.

I have resolved these issues with a small fix but the additional no_data line and -9999 values must be addressed with another elif statement.